### PR TITLE
refactor: match 엔티티 테이블 명 변경 #1

### DIFF
--- a/src/main/java/hsge/hsgeback/entity/Match.java
+++ b/src/main/java/hsge/hsgeback/entity/Match.java
@@ -8,6 +8,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Getter
 @Entity
+@Table(name = "matching")
 public class Match extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
mariaDB의 예약어로 Match가 있어서 충돌납니다.